### PR TITLE
Feature/websoecket send

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 import time
 import uuid
 from typing import List
+from collections import defaultdict
 
 app = FastAPI()
 
@@ -24,7 +25,7 @@ class CreateMessageRequest(BaseModel):
 
 class ConnectionManager:
     def __init__(self):
-        self.active_connections: dict[str, List[WebSocket]] = {}
+        self.active_connections: dict[str, List[WebSocket]] = defaultdict(lambda: [])
 
     async def connect(self, websocket: WebSocket, room_id: str):
         await websocket.accept()
@@ -80,11 +81,20 @@ async def room(room_id:str):
 #メッセージ新規作成
 @app.post("/rooms/{room_id}/messages")
 async def create_message(room_id:str, message_request:CreateMessageRequest):
+    now = int(time.time())
+    message = {
+      "type":"messages/new",
+      "id": message_request.id,
+      "roomId": room_id,
+      "message": message_request.message,
+      "createdAt": now
+    }
+    await manager.broadcast(room_id, str(message))
     return {
       "id": message_request.id,
       "roomId": room_id,
       "message": message_request.message,
-      "createdAt": int(time.time())
+      "createdAt": now
     }
 
 @app.websocket("/rooms/{room_id}")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -85,14 +85,12 @@ async def create_message(room_id:str, message_request:CreateMessageRequest):
     message = {
       "type":"messages/new",
       "id": message_request.id,
-      "roomId": room_id,
       "message": message_request.message,
       "createdAt": now
     }
     await manager.broadcast(room_id, str(message))
     return {
       "id": message_request.id,
-      "roomId": room_id,
       "message": message_request.message,
       "createdAt": now
     }

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -17,7 +17,7 @@ app.add_middleware(
 )
 
 class CreateRoomRequest(BaseModel):
-    roomName: str
+    name: str
 
 class CreateMessageRequest(BaseModel):
     id: str
@@ -54,8 +54,8 @@ async def root():
 @app.post("/rooms")
 async def create_room(room_request:CreateRoomRequest):
     return {
-      "roomId": uuid.uuid4(),
-      "roomName": room_request.roomName
+      "id": uuid.uuid4(),
+      "name": room_request.name
     }
 
 #ルーム情報取得


### PR DESCRIPTION
メッセージ新規作成のエンドポイントを変更した
メッセージ内容を同じroomにいる人に送信するようにプログラムを追記した

room情報が定義されていない時は空の配列を返すようにした

仕様書のChange Logにもある通り、message型のroom_idを削除した
room型のroomIdとroomNameをidとnameに変更した
https://docs.google.com/document/d/1_IXueceDxD09tLgtLs7WkRmSm4Cq5oGpRrQI3rgKX8A/edit?tab=t.0