### PR TITLE
盛り上がりゲージを追加

### DIFF
--- a/frontend/src/components/message/MoodGage.tsx
+++ b/frontend/src/components/message/MoodGage.tsx
@@ -22,7 +22,8 @@ export function MoodGage({ percentage }: { percentage: number }) {
     <Wrapper>
       <MaxText
         style={{
-          color: percentage == 100 ? tickColors[tickColors.length-1] : '#D0D0D0',
+          color:
+            percentage == 100 ? tickColors[tickColors.length - 1] : '#D0D0D0',
         }}
       >
         Max

--- a/frontend/src/components/message/MoodGage.tsx
+++ b/frontend/src/components/message/MoodGage.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import styled from 'styled-components';
+
+export function MoodGage({ percentage }: { percentage: number }) {
+  const tickColors: string[] = useMemo(
+    () => [
+      '#7c50ed',
+      '#7c50ed',
+      '#7c50ed',
+      '#5687dc',
+      '#5687dc',
+      '#5687dc',
+      '#5687dc',
+      '#d85bc8',
+      '#d85bc8',
+      '#d85bc8',
+    ],
+    [],
+  );
+
+  return (
+    <Wrapper>
+      <MaxText
+        style={{
+          color: percentage == 100 ? tickColors[tickColors.length-1] : '#D0D0D0',
+        }}
+      >
+        Max
+      </MaxText>
+      <GageStack>
+        {new Array(10).fill(0).map((_, index) => {
+          const isFilled = index < percentage / 10;
+          return (
+            <GageTick
+              key={index}
+              tickColor={isFilled ? tickColors[index] : '#D0D0D0'}
+            />
+          );
+        })}
+      </GageStack>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  width: 100px;
+`;
+
+const MaxText = styled.div`
+  font-size: 20px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.1);
+`;
+
+const GageStack = styled.div`
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 4px;
+  width: 100%;
+`;
+
+const GageTick = styled.div<{ tickColor?: string }>`
+  width: 100%;
+  height: 10px;
+  border-radius: 10px;
+  background-color: ${({ tickColor }) => tickColor || '#d0d0d0'};
+  box-shadow: 0 0 2px ${({ tickColor }) => tickColor || '#d0d0d0'};
+`;

--- a/frontend/src/components/message/MoodGage.tsx
+++ b/frontend/src/components/message/MoodGage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import styled from 'styled-components';
 
 export function MoodGage({ percentage }: { percentage: number }) {
@@ -22,7 +22,8 @@ export function MoodGage({ percentage }: { percentage: number }) {
     <Wrapper>
       <MaxText
         style={{
-          color: percentage == 100 ? tickColors[tickColors.length-1] : '#D0D0D0',
+          color:
+            percentage == 100 ? tickColors[tickColors.length - 1] : '#D0D0D0',
         }}
       >
         Max

--- a/frontend/src/components/message/MoodGage.tsx
+++ b/frontend/src/components/message/MoodGage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 
 export function MoodGage({ percentage }: { percentage: number }) {
@@ -22,8 +22,7 @@ export function MoodGage({ percentage }: { percentage: number }) {
     <Wrapper>
       <MaxText
         style={{
-          color:
-            percentage == 100 ? tickColors[tickColors.length - 1] : '#D0D0D0',
+          color: percentage == 100 ? tickColors[tickColors.length-1] : '#D0D0D0',
         }}
       >
         Max
@@ -34,7 +33,7 @@ export function MoodGage({ percentage }: { percentage: number }) {
           return (
             <GageTick
               key={index}
-              tickColor={isFilled ? tickColors[index] : '#D0D0D0'}
+              $tickColor={isFilled ? tickColors[index] : '#D0D0D0'}
             />
           );
         })}
@@ -64,10 +63,10 @@ const GageStack = styled.div`
   width: 100%;
 `;
 
-const GageTick = styled.div<{ tickColor?: string }>`
+const GageTick = styled.div<{ $tickColor?: string }>`
   width: 100%;
   height: 10px;
   border-radius: 10px;
-  background-color: ${({ tickColor }) => tickColor || '#d0d0d0'};
-  box-shadow: 0 0 2px ${({ tickColor }) => tickColor || '#d0d0d0'};
+  background-color: ${({ $tickColor }) => $tickColor || '#d0d0d0'};
+  box-shadow: 0 0 2px ${({ $tickColor }) => $tickColor || '#d0d0d0'};
 `;

--- a/frontend/src/hooks/useRoom.ts
+++ b/frontend/src/hooks/useRoom.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { RoomApi } from 'src/data/RoomApi';
-import { Message } from 'src/models/Message';
+import { calcMoodPercentage, Message } from 'src/models/Message';
 import { Room } from 'src/models/Room';
 import { v4 as uuidv4 } from 'uuid';
 
 export const useRoom = ({ roomId }: { roomId: string }) => {
   const [room, setRoom] = useState<Room | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
+  const [moodPercentage, setMoodPercentage] = useState<number>(0);
 
   const sendMessage = useCallback(
     async ({ value }: { value: string }) => {
@@ -75,9 +76,27 @@ export const useRoom = ({ roomId }: { roomId: string }) => {
     };
   }, [room]);
 
+  // 盛り上がり度を1秒間隔で計算
+  useEffect(() => {
+    setMoodPercentage(
+      calcMoodPercentage({
+        messages,
+      }),
+    );
+
+    const interval = setInterval(() => {
+      setMoodPercentage(calcMoodPercentage({ messages }));
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [messages]);
+
   return {
     room,
     messages,
     sendMessage,
+    moodPercentage,
   };
 };

--- a/frontend/src/models/Message.ts
+++ b/frontend/src/models/Message.ts
@@ -30,3 +30,24 @@ export function isEmoji(reactionText: string) {
   );
   return regEmoji.test(reactionText);
 }
+
+/**
+ * @param durationInSec: 考慮するメッセージの時間範囲（秒） この時間が長いと、盛り上がり度の動きが小さくなる。
+ * @param maxMessageCount: 100%とするメッセージ数
+ * @returns 盛り上がり度をパーセンテージで返す(0-100)
+ */
+export function calcMoodPercentage({
+  messages,
+  durationInSec = 30,
+  maxMessageCount = 50,
+}: {
+  messages: Message[];
+  durationInSec?: number;
+  maxMessageCount?: number;
+}): number {
+  const startAt = Date.now() - durationInSec * 1000;
+  const messagesInDuration = messages.filter(
+    (message) => message.createdAt > startAt,
+  );
+  return Math.min(messagesInDuration.length / maxMessageCount, 1.0) * 100;
+}

--- a/frontend/src/pages/rooms/[id]/index.tsx
+++ b/frontend/src/pages/rooms/[id]/index.tsx
@@ -11,7 +11,9 @@ export default function RoomPage() {
   const router = useRouter();
   const { id } = useMemo(() => router.query, [router.query]);
   const [inputText, setInputText] = useState('');
-  const { room, messages, sendMessage } = useRoom({ roomId: id as string });
+  const { messages, sendMessage, moodPercentage } = useRoom({
+    roomId: id as string,
+  });
   const reactions = [...REACTION_TEXT.NEGATIVE, ...REACTION_TEXT.POSITIVE];
 
   const handleSendMessage = useCallback(() => {
@@ -64,7 +66,7 @@ export default function RoomPage() {
         </MessageFormWrapper>
       </FormWrapper>
       <MoodGageWrapper>
-        <MoodGage percentage={100} />
+        <MoodGage percentage={moodPercentage} />
       </MoodGageWrapper>
     </Wrapper>
   );

--- a/frontend/src/pages/rooms/[id]/index.tsx
+++ b/frontend/src/pages/rooms/[id]/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
 import { MessageDisplay } from 'src/components/message/MessageDisplay';
+import { MoodGage } from 'src/components/message/MoodGage';
 import SendIcon from 'src/components/svg/send.svg';
 import { useRoom } from 'src/hooks/useRoom';
 import { isEmoji, REACTION_TEXT } from 'src/models/Message';
@@ -28,7 +29,6 @@ export default function RoomPage() {
 
   return (
     <Wrapper>
-      <RoomName>Room: {room?.name}</RoomName>
       <MessageDisplay messages={messages} />
       <FormWrapper>
         <ReactionButtonStack>
@@ -63,6 +63,9 @@ export default function RoomPage() {
           </MessageSendButton>
         </MessageFormWrapper>
       </FormWrapper>
+      <MoodGageWrapper>
+        <MoodGage percentage={100} />
+      </MoodGageWrapper>
     </Wrapper>
   );
 }
@@ -70,11 +73,13 @@ export default function RoomPage() {
 const Wrapper = styled.div`
   width: 100%;
   height: 100%;
+  position: relative;
 `;
 
-const RoomName = styled.div`
-  font-size: 24px;
-  font-weight: 500;
+const MoodGageWrapper = styled.div`
+  position: absolute;
+  top: 8px;
+  left: 16px;
 `;
 
 const FormWrapper = styled.div`


### PR DESCRIPTION
## 概要
- 30秒間以内に50メッセージ作成されたら100%となるようなゲージを配置した。

|before|after|
|----|----|
|![image](https://github.com/user-attachments/assets/785a51e1-405e-4998-b096-449c0e3d9506)|![image](https://github.com/user-attachments/assets/2f3aa149-6ca8-4fb1-ad27-aa422b5d6145)||¥