### PR TITLE
メッセージがフォームの下に隠れないようにする

### DIFF
--- a/frontend/src/components/message/MessageDisplay.tsx
+++ b/frontend/src/components/message/MessageDisplay.tsx
@@ -61,7 +61,7 @@ export const MessageDisplay = ({
         <div
           key={index}
           style={{
-            fontSize: 32,
+            fontSize: 64,
             opacity: message.animationParams.opacity,
             position: 'absolute',
             top: message.animationParams.position.y,

--- a/frontend/src/constants/Size.ts
+++ b/frontend/src/constants/Size.ts
@@ -1,0 +1,14 @@
+export const Size = {
+  Room: {
+    Form: {
+      MessageArea: {
+        height: 48,
+      },
+      ReactionButton: {
+        height: 50,
+      },
+      gap: 8,
+      padding: 16,
+    },
+  },
+};

--- a/frontend/src/models/MessageWithAnimation.ts
+++ b/frontend/src/models/MessageWithAnimation.ts
@@ -1,6 +1,7 @@
+import { Size } from 'src/constants/Size';
 import { Message } from 'src/models/Message';
 import { Position } from 'src/models/Positive';
-import { Size } from 'src/models/Size';
+import { Size as SizeType } from 'src/models/Size';
 
 export type MessageWithAnimation = {
   id: string;
@@ -25,13 +26,19 @@ export function createMessageWithAnimation({
   opacity = 1,
 }: {
   message: Message;
-  windowSize: Size;
+  windowSize: SizeType;
   enterAt?: number;
   opacity?: number;
   scale?: number;
   blur?: number;
 }): MessageWithAnimation {
   const padding = 64;
+  const formHeight =
+    Size.Room.Form.MessageArea.height +
+    Size.Room.Form.ReactionButton.height +
+    Size.Room.Form.gap +
+    padding;
+
   return {
     id: message.id,
     message: message.message,
@@ -41,7 +48,7 @@ export function createMessageWithAnimation({
       opacity,
       position: {
         x: Math.random() * (windowSize.width - padding) + padding,
-        y: Math.random() * (windowSize.height - padding) + padding,
+        y: Math.random() * (windowSize.height - padding - formHeight) + padding,
       },
       scale: 1,
       blur: 0,

--- a/frontend/src/pages/rooms/[id]/index.tsx
+++ b/frontend/src/pages/rooms/[id]/index.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
 import { MessageDisplay } from 'src/components/message/MessageDisplay';
 import SendIcon from 'src/components/svg/send.svg';
+import { Size } from 'src/constants/Size';
 import { useRoom } from 'src/hooks/useRoom';
 import { isEmoji, REACTION_TEXT } from 'src/models/Message';
 import styled from 'styled-components';
@@ -81,8 +82,8 @@ const FormWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px;
-  gap: 8px;
+  padding: ${Size.Room.Form.padding}px;
+  gap: ${Size.Room.Form.gap}px;
 
   position: fixed;
   bottom: 0;
@@ -99,7 +100,7 @@ const MessageFormWrapper = styled.div`
 
 const MessageFormInputArea = styled.div`
   flex: 1;
-  height: 50px;
+  height: ${Size.Room.Form.MessageArea.height}px;
   display: flex;
 
   background-color: white;
@@ -148,8 +149,8 @@ const ReactionButtonStack = styled.div`
 
 const BaseReactionButton = styled.button`
   cursor: pointer;
-  width: 48px;
-  height: 48px;
+  width: ${Size.Room.Form.ReactionButton.height}px;
+  height: ${Size.Room.Form.ReactionButton.height}px;
   padding: 2px;
   border-radius: 20px;
   background-color: white;


### PR DESCRIPTION
### 概要
- メッセージを表示するときに、フォームより上の位置にメッセージをポップすることで、フォームに隠れないようにした。

|before|after|
|-----|---|
|![image](https://github.com/user-attachments/assets/bbf53e76-c991-4018-afbc-b95becbb11d9)|![image](https://github.com/user-attachments/assets/563697c2-4cd4-4184-bef6-5b13718349a1)|
|画面下部のギリギリの場所にも表示される|フォームより上に表示される|