### PR TITLE
db周りの修正

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -121,6 +121,8 @@ async def room(room_id:str):
 
     return room_data
 
+faces = ['👍', '🥹', '🤩', '🤯', '😑', '🤔']
+
 #メッセージ新規作成
 @app.post("/rooms/{room_id}/messages")
 async def create_message(room_id:str, message_request:CreateMessageRequest):
@@ -133,12 +135,13 @@ async def create_message(room_id:str, message_request:CreateMessageRequest):
     }
     await manager.broadcast(room_id, json.dumps(message))
 
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(f"INSERT INTO messages (id,message,created_at,room_id) VALUES('{message['id']}','{message['message']}','{message['createdAt']}','{room_id}')")
-    conn.commit()
-    cur.close()
-    conn.close()
+    if message_request.message not in faces:
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute(f"INSERT INTO messages (id,message,created_at,room_id) VALUES('{message['id']}','{message['message']}','{message['createdAt']}','{room_id}')")
+        conn.commit()
+        cur.close()
+        conn.close()
 
     return {
       "id": message_request.id,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -64,8 +64,7 @@ def get_connection():
         conn = db_pool.getconn()
         return conn
     except Exception as e:
-        print(f"接続の取得に失敗しました: {e}")
-        return None
+        raise e
 
 def release_connection(conn):
     if conn:


### PR DESCRIPTION
- 特定の顔文字はDBに保存しないように処理を追加
- エンドポイントごとに毎回DBに接続・切断するのではなく、psycopg2のコネクションプーリングを使って接続を再利用する形に変更