### PR TITLE
ルームの名前が表示されるようにする

### DIFF
--- a/frontend/src/components/message/MessageDisplay.tsx
+++ b/frontend/src/components/message/MessageDisplay.tsx
@@ -84,6 +84,4 @@ const Wrapper = styled.div`
   max-height: 100%;
   position: relative;
   overflow: hidden;
-
-  background-color: #f0f0f0;
 `;

--- a/frontend/src/pages/rooms/[id]/index.tsx
+++ b/frontend/src/pages/rooms/[id]/index.tsx
@@ -57,6 +57,11 @@ export default function RoomPage() {
 
   return (
     <Wrapper>
+      {room && isTutorialDone && (
+        <RoomNameWrapper>
+          <RoomName>{room.name}</RoomName>
+        </RoomNameWrapper>
+      )}
       <MessageDisplay messages={messages} />
       <Tutorial
         isVisible={!!room && !isTutorialDone}
@@ -108,6 +113,7 @@ const Wrapper = styled.div`
   width: 100%;
   height: 100%;
   position: relative;
+  background-color: #f0f0f0;
 `;
 
 const MoodGageWrapper = styled.div`
@@ -215,4 +221,18 @@ const PhraseReactionButton = styled(BaseReactionButton)`
   width: auto;
   white-space: nowrap;
   padding-inline: 6px;
+`;
+
+const RoomNameWrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+const RoomName = styled.div`
+  font-size: 64px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.1);
+  z-index: 1;
 `;


### PR DESCRIPTION
### 概要
- ルームページでルームの名前が表示されるようにした。

||
|---|
|<img width="1452" alt="image" src="https://github.com/user-attachments/assets/0f5a2245-0697-4e9b-ad80-cec2e5c4b50d">|