### PR TITLE
？のあるメッセージのみ表示

### DIFF
--- a/frontend/src/components/message/MessageHistory.tsx
+++ b/frontend/src/components/message/MessageHistory.tsx
@@ -50,7 +50,7 @@ export function MessageHistory({
             }}
           >
             {messages
-              .filter((messages) => !defaultMessage.includes(messages.message))
+              .filter((messages) => !defaultMessage.includes(messages.message) && messages.score == 1)
               .map((message) => (
                 <VStack style={{ gap: 0 }} key={message.id}>
                   <MessageText

--- a/frontend/src/components/message/MessageHistory.tsx
+++ b/frontend/src/components/message/MessageHistory.tsx
@@ -1,4 +1,4 @@
-import { Message } from 'src/models/Message';
+import { isQuestion, Message } from 'src/models/Message';
 import styled from 'styled-components';
 import { HStack } from '../common/HStack';
 import { VStack } from '../common/VStack';
@@ -50,11 +50,8 @@ export function MessageHistory({
             }}
           >
             {messages
-              .filter(
-                (messages) =>
-                  !defaultMessage.includes(messages.message) &&
-                  messages.score == 1,
-              )
+              .filter((messages) => !defaultMessage.includes(messages.message))
+              .filter((messages) => isQuestion(messages))
               .map((message) => (
                 <VStack style={{ gap: 0 }} key={message.id}>
                   <MessageText

--- a/frontend/src/components/message/MessageHistory.tsx
+++ b/frontend/src/components/message/MessageHistory.tsx
@@ -50,7 +50,11 @@ export function MessageHistory({
             }}
           >
             {messages
-              .filter((messages) => !defaultMessage.includes(messages.message) && messages.score == 1)
+              .filter(
+                (messages) =>
+                  !defaultMessage.includes(messages.message) &&
+                  messages.score == 1,
+              )
               .map((message) => (
                 <VStack style={{ gap: 0 }} key={message.id}>
                   <MessageText

--- a/frontend/src/components/message/MessageHistory.tsx
+++ b/frontend/src/components/message/MessageHistory.tsx
@@ -1,4 +1,8 @@
-import { isQuestion, Message } from 'src/models/Message';
+import {
+  isMessageContainedArray,
+  isQuestion,
+  Message,
+} from 'src/models/Message';
 import styled from 'styled-components';
 import { HStack } from '../common/HStack';
 import { VStack } from '../common/VStack';
@@ -17,16 +21,6 @@ export function MessageHistory({
   if (!isOpen) {
     return null;
   }
-  const defaultMessage = [
-    '👍',
-    '😁',
-    '🤩',
-    '🤯',
-    '😑',
-    '🤔',
-    'わかる',
-    'ざわざわ',
-  ];
 
   return (
     <DialogOverlay onClick={onClickOutside}>
@@ -50,7 +44,19 @@ export function MessageHistory({
             }}
           >
             {messages
-              .filter((messages) => !defaultMessage.includes(messages.message))
+              .filter(
+                (messages) =>
+                  !isMessageContainedArray(messages, [
+                    '👍',
+                    '😁',
+                    '🤩',
+                    '🤯',
+                    '😑',
+                    '🤔',
+                    'わかる',
+                    'ざわざわ',
+                  ]),
+              )
               .filter((messages) => isQuestion(messages))
               .map((message) => (
                 <VStack style={{ gap: 0 }} key={message.id}>

--- a/frontend/src/data/RoomApi.ts
+++ b/frontend/src/data/RoomApi.ts
@@ -39,6 +39,7 @@ export class RoomApi {
     return {
       id: response.data['id'],
       message: response.data['message'],
+      score: response.data['score'],
       createdAt: response.data['createdAt'],
     };
   }

--- a/frontend/src/models/Message.ts
+++ b/frontend/src/models/Message.ts
@@ -1,6 +1,7 @@
 export type Message = {
   id: string;
   message: string;
+  score: number;
   createdAt: number;
 };
 

--- a/frontend/src/models/Message.ts
+++ b/frontend/src/models/Message.ts
@@ -53,7 +53,14 @@ export function calcMoodPercentage({
   return Math.min(messagesInDuration.length / maxMessageCount, 1.0) * 100;
 }
 
-export function isQuestion(message: Message): boolean{
-  if (message.score === undefined) return false
-  return message.score >=0
+export function isQuestion(message: Message): boolean {
+  if (message.score === undefined) return false;
+  return message.score >= 0;
+}
+
+export function isMessageContainedArray(
+  message: Message,
+  array: string[],
+): boolean {
+  return array.includes(message.message);
 }

--- a/frontend/src/models/Message.ts
+++ b/frontend/src/models/Message.ts
@@ -1,7 +1,7 @@
 export type Message = {
   id: string;
   message: string;
-  score: number;
+  score?: number;
   createdAt: number;
 };
 
@@ -51,4 +51,9 @@ export function calcMoodPercentage({
     (message) => message.createdAt > startAt,
   );
   return Math.min(messagesInDuration.length / maxMessageCount, 1.0) * 100;
+}
+
+export function isQuestion(message: Message): boolean{
+  if (message.score === undefined) return false
+  return message.score >=0
 }


### PR DESCRIPTION
メッセージ履歴に表示するメッセージを？が含まれているメッセージ（scoreが1）のみに変更
![スクリーンショット 2024-12-11 20 11 43](https://github.com/user-attachments/assets/fac994ee-514b-44f8-a8aa-239b2eb7daee)
